### PR TITLE
Hostlist cmd travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ install:
 script:
     - python hostlist/unittest_hostlist.py
     - coverage run hostlist/unittest_hostlist.py
+    - hostlist/hostlist -h 
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
     - python hostlist/unittest_hostlist.py
     - coverage run hostlist/unittest_hostlist.py
-    - python setup.py sdist bdist_wheel bdist_rpm
+    - python setup.py sdist bdist_wheel
     - hostlist -h
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 script:
     - python hostlist/unittest_hostlist.py
     - coverage run hostlist/unittest_hostlist.py
-    - hostlist/hostlist -h 
+    - python setup.py sdist bdist_wheel bdist_rpm
+    - hostlist -h
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
     - python hostlist/unittest_hostlist.py
     - coverage run hostlist/unittest_hostlist.py
     - python setup.py sdist bdist_wheel
+    - pip install dist/py_hostlist-0.0.1.dev0-py2.py3-none-any.whl
     - hostlist -h
 after_success:
     - codecov


### PR DESCRIPTION
Figured it out! In order to run the command-line version of py-hostlist, we need to add a couple of lines to our `.travis.yml` file:

`python setup.py sdist bdist_wheel` builds our project so that we have a distribution file

`pip install dist/py_hostlist-0.0.1.dev0-py2.py3-none-any.whl` installs our newly developed package and adds `hostlist` to our environment so we can use it on the command line

`hostlist -h` confirms its functionality