### PR TITLE
.travis.yml: remove unneeded Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-    - "2.7"
-    - "3.3"
-    - "3.4"
     - "3.5"
     - "3.5-dev"  # 3.5 development branch
     - "3.6"


### PR DESCRIPTION
The current `.travis.yml` file checks for Python versions `2.7`, `3.3`, and `3.4`. These versions do not need to be checked for, so remove them.
