### PR TITLE
Add a break to lead 0 count

### DIFF
--- a/hostlist/hostlist.py
+++ b/hostlist/hostlist.py
@@ -105,6 +105,8 @@ def expand(nodelist):
                         if digit == '0':
                             lead_zeros = lead_zeros + 1
                             lead_zeros_str = lead_zeros_str + '0'
+                        else:
+                            break
 
                     rng_list = range(int(tmp_list[0]), int(tmp_list[1]) + 1)
                     final_list.extend(rng_list)


### PR DESCRIPTION
Fix issue with range containing zeroes that are leading, for example "host[1-10,1001-1003]" would add two leading zeroes to host1 to host10 while there are supposed to be none.