### PR TITLE
`expand()`: handle case of multiple ranges with leading zeros

### DIFF
--- a/hostlist/unittest_hostlist.py
+++ b/hostlist/unittest_hostlist.py
@@ -20,6 +20,12 @@ class TestHostlistMethods(unittest.TestCase):
         test = hl.expand('quartz[4-8]')
         self.assertEqual(test, expected)
 
+    # expand() with the prompt in issue#32
+    def test_expand_leading_zeros(self):
+        expected = 's02p017,s02p029,s02p030'
+        test = hl.expand('s02p[017,029-030]')
+        self.assertEqual(test, expected)
+
     # expand() will also return correctly with
     # multiple sets of ranges
     def test_expand_multi_range(self):


### PR DESCRIPTION
#### Problem

As noted in https://github.com/LLNL/py-hostlist/issues/32, the expand() function doesn't correctly handle hostlists with leading zeros in the ranges.

---

This PR reworks and restructures the `expand()` function to correctly handle ranges of leading zeros, particularly when there are multiple ranges.

It also adds a unit test using the example provided in https://github.com/LLNL/py-hostlist/issues/32 to confirm it is working as expected.

Fixes #32
