### PR TITLE
cmd: import `hostlist` module, bump version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
     - python hostlist/unittest_hostlist.py
     - coverage run hostlist/unittest_hostlist.py
     - python setup.py sdist bdist_wheel
-    - pip install dist/py_hostlist-0.0.1.dev0-py2.py3-none-any.whl
+    - pip install dist/*.whl
     - hostlist -h
 after_success:
     - codecov

--- a/hostlist/__init__.py
+++ b/hostlist/__init__.py
@@ -3,4 +3,6 @@
 .. moduleauthor:: Christopher Moussa <moussa1@llnl.gov>
 
 """
+from .hostlist import *
+
 name = "py-hostlist"

--- a/hostlist/cla_hostlist.py
+++ b/hostlist/cla_hostlist.py
@@ -15,7 +15,7 @@ def msg(name=None):
     Description: cla_hostlist processes slurm-style hostlist strings and
     can return those strings in manipulated fashion.
 
-    Usage: python cla_hostlist.py [OPTION]... [HOSTLIST]...
+    Usage: hostlist [OPTION]... [HOSTLIST]...
 
     -h, --help                   Display this message.
     -q, --quiet                  Quiet output (exit non-zero if empty hostlist)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="py-hostlist",
-    version="0.0.1-dev",
+    version="0.1.0",
     author="Christopher Moussa",
     author_email="moussa1@llnl.gov",
     description="A slurm-style hostlist processor.",


### PR DESCRIPTION
#### Problem

Building the `hostlist` package with the commands listed in the start page does not allow for actual use of any of the `hostlist` commands and instead raises an `AttributeError` complaining that it can't find any of the functions.

---

This PR adds the import of the `hostlist` package to `__init__.py` so that the command-line interface can actually utilize the functions defined in `hostlist.py` and a user can run things like `hostlist -e node[1-4]` instead of `python cla_hostlist.py -e node[1-4]`.

It also bumps the version of the py-hostlist package to `0.1.0`.