### PR TITLE
README: update link to Features page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 py-hostlist processes slurm-style hostlist strings and can return those strings in manipulated fashion.
 
-See the [Feature Overview](https://py-hostlist.readthedocs.io/en/latest/features.html) for examples and highlights.
+See the [Feature Overview](https://py-hostlist.readthedocs.io/en/latest/source/features.html) for examples and highlights.
 
 ## Documentation
 


### PR DESCRIPTION
#### Problem

The **Features** hyperlink on the top-level `README` results in a 404 Page Not Found error.

---

This PR fixes the hyperlink to the **Features** page.