### PR TITLE
[WIP] docs: update example usage of `hostlist` command

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -4,7 +4,7 @@ Basic Usage
 
 You can use the command line to process your hostlist strings by using the following command:
 
-``python cla_hostlist.py <method> <args>...``
+``hostlist <method> <args>...``
 
 Here is a list of all of the methods available:
 
@@ -45,6 +45,6 @@ Here is a list of all of the methods available:
 
 For example, to execute the expand function displayed above, users can run the following:
 
-``python cla_hostlist.py -e node[1-4]``
+``hostlist -e node[1-4]``
 
 This will return ``node1,node2,node3,node4``.

--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -4,7 +4,7 @@ py-hostlist Man Page
 SYNOPSIS
 --------
 
-``python cla_hostlist.py [OPTION] ARGS``
+``hostlist [OPTION] ARGS``
 
 DESCRIPTION
 -----------
@@ -98,31 +98,31 @@ EXAMPLES
 
 1. To expand a hostlist:
 
-   ``python cla_hostlist.py -e foo[1-5]``
+   ``hostlist -e foo[1-5]``
 
 2. To set a custom delimiter:
 
-   ``python cla_hostlist.py -d [DELIMITER] foo[1-5]``
+   ``hostlist -d [DELIMITER] foo[1-5]``
 
 3. To see the first N hosts:
 
-   ``python cla_hostlist.py -s [N] foo[1-5]``
+   ``hostlist -s [N] foo[1-5]``
 
 4. To exclude a node from a hostlist:
 
-   ``python cla_hostlist.py -x foo[1-5] [EXCLUDED NODE] [EXCLUDED NODE]...``
+   ``hostlist -x foo[1-5] [EXCLUDED NODE] [EXCLUDED NODE]...``
 
 5. To find the nth host in a hostlist:
 
-   ``python cla_hostlist.py -n [N] foo[1-5]``
+   ``hostlist -n [N] foo[1-5]``
 
 6. To remove all occurences of a node from a hostlist:
 
-   ``python cla_hostlist.py -R [NODE] foo[1-5]``
+   ``hostlist -R [NODE] foo[1-5]``
 
 7. To find the position of a specific node:
 
-   ``python cla_hostlist.py -F [NODE] foo[1-50]``
+   ``hostlist -F [NODE] foo[1-50]``
 
 
 


### PR DESCRIPTION
#### Problem

The docs gives examples of how to use the `hostlist` command by directly executing `cla_hostlist.py` with `python`. This should be updated to just use `hostlist` after installing the package.

---

This PR updates the example usage in the docs to just use `hostlist` instead of `python cla_hostlist.py`. This PR should not be merged until #37 has been approved and landed.